### PR TITLE
파티클 정리본(슬랙)

### DIFF
--- a/Computer Virus Survivors/Assets/Prefabs/Weapon02_CoreDump/Prf_CoreDump.prefab
+++ b/Computer Virus Survivors/Assets/Prefabs/Weapon02_CoreDump/Prf_CoreDump.prefab
@@ -108,7 +108,7 @@ ParticleSystem:
       m_RotationOrder: 4
   moveWithTransform: 1
   moveWithCustomTransform: {fileID: 0}
-  scalingMode: 2
+  scalingMode: 0
   randomSeed: 0
   InitialModule:
     serializedVersion: 3
@@ -4849,7 +4849,7 @@ ParticleSystem:
       m_RotationOrder: 4
   moveWithTransform: 1
   moveWithCustomTransform: {fileID: 0}
-  scalingMode: 2
+  scalingMode: 0
   randomSeed: 0
   InitialModule:
     serializedVersion: 3
@@ -9723,7 +9723,7 @@ ParticleSystem:
       m_RotationOrder: 4
   moveWithTransform: 1
   moveWithCustomTransform: {fileID: 0}
-  scalingMode: 2
+  scalingMode: 0
   randomSeed: 0
   InitialModule:
     serializedVersion: 3

--- a/Computer Virus Survivors/Assets/Prefabs/Weapon03_FlameThrower/Prf_FlameThrower.prefab
+++ b/Computer Virus Survivors/Assets/Prefabs/Weapon03_FlameThrower/Prf_FlameThrower.prefab
@@ -111,7 +111,7 @@ ParticleSystem:
       m_RotationOrder: 4
   moveWithTransform: 1
   moveWithCustomTransform: {fileID: 0}
-  scalingMode: 2
+  scalingMode: 0
   randomSeed: 0
   InitialModule:
     serializedVersion: 3

--- a/Computer Virus Survivors/Assets/Prefabs/Weapon03_FlameThrower/Prf_FlameThrower_Revised.prefab
+++ b/Computer Virus Survivors/Assets/Prefabs/Weapon03_FlameThrower/Prf_FlameThrower_Revised.prefab
@@ -30,7 +30,7 @@ Transform:
   m_GameObject: {fileID: 2344565341498810400}
   m_LocalRotation: {x: 0, y: -0.92387956, z: 0, w: 0.38268343}
   m_LocalPosition: {x: 0, y: 0, z: 4.29}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 2344565342047825442}
@@ -109,9 +109,9 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 2
   moveWithCustomTransform: {fileID: 0}
-  scalingMode: 2
+  scalingMode: 0
   randomSeed: 0
   InitialModule:
     serializedVersion: 3
@@ -4885,7 +4885,7 @@ Transform:
   m_GameObject: {fileID: 2344565341627522368}
   m_LocalRotation: {x: 0, y: -0.5555702, z: 0, w: 0.8314697}
   m_LocalPosition: {x: 0, y: 0, z: 4.29}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 2344565342047825442}
@@ -4964,9 +4964,9 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 2
   moveWithCustomTransform: {fileID: 0}
-  scalingMode: 2
+  scalingMode: 0
   randomSeed: 0
   InitialModule:
     serializedVersion: 3
@@ -9740,7 +9740,7 @@ Transform:
   m_GameObject: {fileID: 2344565342026948677}
   m_LocalRotation: {x: 0, y: -0.83146966, z: 0, w: 0.55557024}
   m_LocalPosition: {x: 0, y: 0, z: 4.29}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 2344565342047825442}
@@ -9819,9 +9819,9 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 2
   moveWithCustomTransform: {fileID: 0}
-  scalingMode: 2
+  scalingMode: 0
   randomSeed: 0
   InitialModule:
     serializedVersion: 3
@@ -14721,7 +14721,7 @@ Transform:
   m_GameObject: {fileID: 2344565343090411197}
   m_LocalRotation: {x: 0, y: -0.38268343, z: 0, w: 0.92387956}
   m_LocalPosition: {x: 0, y: 0, z: 4.29}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 2344565342047825442}
@@ -14800,9 +14800,9 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 2
   moveWithCustomTransform: {fileID: 0}
-  scalingMode: 2
+  scalingMode: 0
   randomSeed: 0
   InitialModule:
     serializedVersion: 3
@@ -19609,7 +19609,7 @@ Transform:
   m_GameObject: {fileID: 2344565343141297653}
   m_LocalRotation: {x: -0, y: -0.7071068, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 4.29}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 2344565342047825442}
@@ -19688,9 +19688,9 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 2
   moveWithCustomTransform: {fileID: 0}
-  scalingMode: 2
+  scalingMode: 0
   randomSeed: 0
   InitialModule:
     serializedVersion: 3

--- a/Computer Virus Survivors/Assets/Prefabs/Weapon03_FlameThrower/Scripts/FlameThrowerController.cs
+++ b/Computer Virus Survivors/Assets/Prefabs/Weapon03_FlameThrower/Scripts/FlameThrowerController.cs
@@ -1,3 +1,4 @@
+//본 스크립트는 애니메이션이 정상 작동하는지 확인하기 위해 임시로 만든 스크립트입니다. 실제 사용시 삭제하시면 됩니다. 화염방사기 발사 애니메이션 파라미터는 "Fire_b" 입니다.s
 using UnityEngine;
 
 public class FlameThrowerController : MonoBehaviour


### PR DESCRIPTION
-코어덤프, 화염방사기 파티클 오브젝트 전부 Scailing mode를 Shape에서 Hierachy로 변경, Transform으로 파티클 크기 조절 가능
-기타 변경 사항은 슬랙