### PR TITLE
Feature/movement  fix: 벽 충돌시 떨림

### DIFF
--- a/Computer Virus Survivors/Assets/PacketStream_Short.unitypackage.meta
+++ b/Computer Virus Survivors/Assets/PacketStream_Short.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 07e381987fa3b274e9288c1a0f5f7ee0
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Computer Virus Survivors/Assets/Prefabs/W_FlameThrower.prefab
+++ b/Computer Virus Survivors/Assets/Prefabs/W_FlameThrower.prefab
@@ -125,7 +125,7 @@ ParticleSystem:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  moveWithTransform: 1
+  moveWithTransform: 0
   moveWithCustomTransform: {fileID: 0}
   scalingMode: 0
   randomSeed: 0

--- a/Computer Virus Survivors/Assets/Scripts/GameManager.cs
+++ b/Computer Virus Survivors/Assets/Scripts/GameManager.cs
@@ -15,6 +15,7 @@ public class GameManager : Singleton<GameManager>
 
     private void Awake()
     {
+        Application.targetFrameRate = 60;
         Initialize();
         GameStart();
     }

--- a/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
@@ -32,7 +32,7 @@ public class PlayerController : MonoBehaviour
     }
 
 
-    private void Update()
+    private void FixedUpdate()
     {
         Move();
 
@@ -99,8 +99,10 @@ public class PlayerController : MonoBehaviour
 
         animator.SetBool("b_IsMoving", moveDirection != Vector3.zero);
 
-        transform.Translate(playerStat.MoveSpeed * Time.deltaTime * moveDirection, Space.World);
-        transform.rotation = Quaternion.LookRotation(moveDirection, Vector3.up);
+        //transform.Translate(playerStat.MoveSpeed * Time.deltaTime * moveDirection, Space.World);
+        rb.MovePosition(transform.position + playerStat.MoveSpeed * Time.deltaTime * moveDirection);
+        //transform.rotation = Quaternion.LookRotation(moveDirection, Vector3.up);
+        rb.MoveRotation(Quaternion.LookRotation(moveDirection, Vector3.up));
         if (playerStat.MoveSpeed < 0)
         {
             transform.rotation *= Quaternion.Euler(0, 180, 0);

--- a/Computer Virus Survivors/Assets/Scripts/Virus/V_Ransomware.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Virus/V_Ransomware.cs
@@ -45,7 +45,7 @@ public class V_Ransomware : VirusBehaviour
         attackActions.Add(FirewallBarricade);
     }
 
-    private void Update()
+    private void FixedUpdate()
     {
         if (!startAttack)
         {

--- a/Computer Virus Survivors/Assets/Scripts/Virus/V_Trojan.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Virus/V_Trojan.cs
@@ -13,7 +13,7 @@ public class V_Trojan : VirusBehaviour
     private bool isAttacking = false;
     private bool doNotTrack = false; // 공격 쿨타임 중에 있음
 
-    private void Update()
+    private void FixedUpdate()
     {
         if (!isAttacking)
         {
@@ -37,9 +37,10 @@ public class V_Trojan : VirusBehaviour
         float elapsedTime = 0f;
         while (elapsedTime < duration)
         {
-            transform.Translate(dashSpeed * Time.deltaTime * Vector3.forward, Space.Self);
-            elapsedTime += Time.deltaTime;
-            yield return null;
+            //transform.Translate(dashSpeed * Time.deltaTime * Vector3.forward, Space.Self);
+            rb.MovePosition(rb.position + dashSpeed * Time.deltaTime * transform.forward);
+            elapsedTime += Time.fixedDeltaTime;
+            yield return new WaitForFixedUpdate();
         }
 
         Debug.Log("Trojan dash END");

--- a/Computer Virus Survivors/Assets/Scripts/Virus/V_Weak.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Virus/V_Weak.cs
@@ -14,7 +14,7 @@ public class V_Weak : VirusBehaviour
     //     contactDamage = 5;
     // }
 
-    private void Update()
+    private void FixedUpdate()
     {
         Move();
         rb.velocity = Vector3.zero;

--- a/Computer Virus Survivors/Assets/Scripts/Virus/VirusBehaviour.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Virus/VirusBehaviour.cs
@@ -35,8 +35,10 @@ public class VirusBehaviour : MonoBehaviour
         Vector3 moveDirection = Vector3.ProjectOnPlane(
             (player.transform.position - transform.position).normalized,
             Vector3.up);
-        transform.Translate(virusData.moveSpeed * Time.deltaTime * moveDirection, Space.World);
-        transform.rotation = Quaternion.LookRotation(moveDirection);
+        //transform.Translate(virusData.moveSpeed * Time.deltaTime * moveDirection, Space.World);
+        rb.MovePosition(transform.position + virusData.moveSpeed * Time.deltaTime * moveDirection);
+        //transform.rotation = Quaternion.LookRotation(moveDirection);
+        rb.MoveRotation(Quaternion.LookRotation(moveDirection));
 #endif
     }
 

--- a/Computer Virus Survivors/Assets/Virus01_Revised.unitypackage.meta
+++ b/Computer Virus Survivors/Assets/Virus01_Revised.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a387b2202c681f649aef914861e4e539
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Computer Virus Survivors/ProjectSettings/TimeManager.asset
+++ b/Computer Virus Survivors/ProjectSettings/TimeManager.asset
@@ -3,7 +3,7 @@
 --- !u!5 &1
 TimeManager:
   m_ObjectHideFlags: 0
-  Fixed Timestep: 0.02
+  Fixed Timestep: 0.016667
   Maximum Allowed Timestep: 0.33333334
   m_TimeScale: 1
   Maximum Particle Timestep: 0.03


### PR DESCRIPTION
https://github.com/2024FALL-SWPP/team-project-for-2024-fall-swpp-team-21/issues/56

rigidbody를 가지고 있는 object에 대해 move를 rb 기반으로 변경하고 fixedupdate안에서 실행시킴
FlameThrower Particle System의 Simulation Space를 Local로 변경

버벅임 문제 해결을 위해 프레임 60 고정 및 fixedupdate 주기 변경
(참고: https://rito15.github.io/posts/unity-fixed-update-and-stuttering/)
그렇지만 버벅임이 아예 없지는 않습니다.(FixedUpdate 때문이 아닐 수도 있긴 합니다.) 그리고 모든 기기에 대해서 적용이 되는지는 잘 모르겠습니다.