### PR TITLE
fix : 바이러스 스폰 이펙트 보완

### DIFF
--- a/Computer Virus Survivors/Assets/Prefabs/Effect/vfx_virusSpawn_type1.prefab
+++ b/Computer Virus Survivors/Assets/Prefabs/Effect/vfx_virusSpawn_type1.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 763281695338473544}
   - component: {fileID: 763281695338473547}
   - component: {fileID: 763281695338473546}
+  - component: {fileID: 7597363187356602015}
   m_Layer: 0
   m_Name: vfx_virusSpawn_type1
   m_TagString: Untagged
@@ -43,7 +44,7 @@ ParticleSystem:
   serializedVersion: 8
   lengthInSec: 2
   simulationSpeed: 1
-  stopAction: 2
+  stopAction: 3
   cullingMode: 0
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
@@ -4092,7 +4093,7 @@ ParticleSystem:
     primitives: []
   SubModule:
     serializedVersion: 2
-    enabled: 1
+    enabled: 0
     subEmitters:
     - serializedVersion: 3
       emitter: {fileID: 0}
@@ -5100,3 +5101,16 @@ ParticleSystemRenderer:
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
   m_MaskInteraction: 0
+--- !u!114 &7597363187356602015
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763281695338473549}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b86cdf755c646a4e93777b914b3b686, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  defaultEffectSize: 0.7

--- a/Computer Virus Survivors/Assets/Scripts/Virus/VirusBehaviour.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Virus/VirusBehaviour.cs
@@ -52,6 +52,30 @@ public class VirusBehaviour : MonoBehaviour
 #endif
     }
 
+    public virtual float GetVirusSize()
+    {
+        Collider coll = GetComponent<Collider>();
+
+        if (coll is SphereCollider)
+        {
+            return ((SphereCollider) coll).radius * transform.localScale.x * 2;
+        }
+        else if (coll is CapsuleCollider)
+        {
+            CapsuleCollider capsule = (CapsuleCollider) coll;
+            return Mathf.Max(capsule.radius, capsule.height / 2) * transform.localScale.x * 2;
+        }
+        else if (coll is BoxCollider)
+        {
+            BoxCollider box = (BoxCollider) coll;
+            return Mathf.Max(box.size.x, box.size.z) * transform.localScale.x;
+        }
+        else
+        {
+            throw new Exception("Collider Type Error");
+        }
+    }
+
     protected virtual void Die()
     {
         OnDie?.Invoke(this);

--- a/Computer Virus Survivors/Assets/Scripts/Virus/VirusSpawnEffect.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Virus/VirusSpawnEffect.cs
@@ -4,8 +4,38 @@ using UnityEngine;
 
 public class VirusSpawnEffect : MonoBehaviour
 {
+
+    private new ParticleSystem particleSystem;
+    private float effectSize;
+    [SerializeField] private float defaultEffectSize = 0.7f;
+    private void Awake()
+    {
+        particleSystem = GetComponent<ParticleSystem>();
+        effectSize = defaultEffectSize;
+    }
+
+    public void SetEffectSize(float size)
+    {
+        effectSize = size;
+    }
+
+    public void SetVirusSize(float virusSize)
+    {
+        particleSystem.transform.localScale = Vector3.one * virusSize * effectSize;
+        transform.position = new Vector3(transform.position.x, virusSize / 2f, transform.position.z);
+    }
+
+    public WaitForSeconds PlayAndWaitUntilEffectPeak()
+    {
+        float spawnDuration = particleSystem.main.duration;
+
+        return new WaitForSeconds(spawnDuration / 2f);
+    }
+
     private void OnParticleSystemStopped()
     {
+        effectSize = defaultEffectSize;
         PoolManager.instance.ReturnObject(PoolType.Virus_SpawnEffect, gameObject);
     }
+
 }

--- a/Computer Virus Survivors/Assets/Scripts/Virus/VirusSpawnFactory.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Virus/VirusSpawnFactory.cs
@@ -24,23 +24,23 @@ public class VirusSpawnFactory : Singleton<VirusSpawnFactory>
 
     private IEnumerator SpawnStart(PoolType index, Vector3 position, Action<VirusBehaviour> callbackOnCreated)
     {
-        Vector3 effectOffset = new Vector3(0, 0.5f, 0);
-        VirusSpawnEffect spawnEffect = PoolManager.instance.GetObject(PoolType.Virus_SpawnEffect, position + effectOffset, Quaternion.identity).GetComponent<VirusSpawnEffect>();
-        float spawnDuration = spawnEffect.GetComponent<ParticleSystem>().main.duration;
-
-        yield return new WaitForSeconds(spawnDuration / 2f);
-
-        Spawn(index, position, callbackOnCreated);
-    }
-
-    private void Spawn(PoolType index, Vector3 position, Action<VirusBehaviour> callbackOnCreated)
-    {
         VirusBehaviour virus = PoolManager.instance.GetObject
         (
             index,
             position,
             Quaternion.identity
         ).GetComponent<VirusBehaviour>();
+        float virusSize = virus.GetVirusSize();
+
+        virus.gameObject.SetActive(false);
+
+        VirusSpawnEffect spawnEffect = PoolManager.instance.GetObject(PoolType.Virus_SpawnEffect, position, Quaternion.identity).GetComponent<VirusSpawnEffect>();
+
+        spawnEffect.SetVirusSize(virusSize);
+
+        yield return spawnEffect.PlayAndWaitUntilEffectPeak();
+
+        virus.gameObject.SetActive(true);
 
         callbackOnCreated(virus);
 


### PR DESCRIPTION
# PR 바이러스 스폰 이펙트 보완
## Related Issue(s)
스폰이펙트의 사이즈를 조절하고싶은 이슈
## PR Description
- 스폰 이펙트의 사이즈를 수동으로 설정할 수 있습니다. 함수명은 SetEffectSize(float size)입니다.
- 스폰 이펙트의 기본 사이즈를 조절할 수 있습니다. 변수명은 defaultEffectSize입니다.
- 바이러스의 사이즈를 반환하는 함수를 만들었습니다. 바이러스의 콜라이더를 기준으로 값을 계산합니다.
- VirusSpawnFactory에서 이펙트를 생성할 때 바이러스의 사이즈가 필요하므로 이펙트보다 바이러스를 먼저 만들게 됩니다. 이때문에 스폰 로직이 변경되었습니다.
- 스폰 이펙트의 메터리얼을 수정하였습니다. 기존의 3x3x3모양의 큐브보다 1x1x1모양의 박스가 더 이뻐보입니다.

### Changes Included
- [x] 바이러스 스폰 이펙트 사이즈 조절
- [x] 바이러스의 사이즈 반환
- [x] 스폰 팩토리의 로직 변경
### Screenshots (if UI changes were made)

### Notes for Reviewer

---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---
## Additional Comments

- 현재 스폰 이펙트의 기본 사이즈는 0.7입니다
