### PR TITLE
트로이목마 버그 bug#126 해결

### DIFF
--- a/Computer Virus Survivors/Assets/Prefabs/Virus_Trojan.prefab
+++ b/Computer Virus Survivors/Assets/Prefabs/Virus_Trojan.prefab
@@ -53,6 +53,9 @@ MonoBehaviour:
   dashSpeed: 25
   dashDelay: 0.3
   dashDuration: 0.5
+  obstacleLayerMask:
+    serializedVersion: 2
+    m_Bits: 4096
 --- !u!54 &5841041427378954022
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -80,8 +83,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1.6737604, y: 3.873436, z: 3.1367903}
-  m_Center: {x: -0.0059695244, y: 1.936718, z: 0.20566207}
+  m_Size: {x: 1.6737604, y: 2, z: 3.1367903}
+  m_Center: {x: -0.0059695244, y: 0, z: 0.20566207}
 --- !u!1001 &2764496335513087531
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Computer Virus Survivors/Assets/Scenes/Stage1Scene.unity
+++ b/Computer Virus Survivors/Assets/Scenes/Stage1Scene.unity
@@ -2955,7 +2955,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: -0.5, z: 0}
 --- !u!23 &544721118
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -8325,7 +8325,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: -0.5, z: 0}
 --- !u!23 &1415802951
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -9672,7 +9672,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: -0.5, z: 0}
 --- !u!23 &1743676891
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -11855,7 +11855,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: -0.5, z: 0}
 --- !u!23 &2142364218
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/Computer Virus Survivors/Assets/Scripts/Virus/V_Trojan.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Virus/V_Trojan.cs
@@ -10,6 +10,7 @@ public class V_Trojan : VirusBehaviour
     [SerializeField] private float dashSpeed = 15.0f;
     [SerializeField] private float dashDelay = 0.3f;
     [SerializeField] private float dashDuration = 0.5f;
+    [SerializeField] private LayerMask obstacleLayerMask;
 
     private bool canAttack = false;
     private bool isAttacking = false;
@@ -65,10 +66,15 @@ public class V_Trojan : VirusBehaviour
         while (elapsedTime < duration)
         {
             //transform.Translate(dashSpeed * Time.deltaTime * Vector3.forward, Space.Self);
-            rb.MovePosition(rb.position + dashSpeed * Time.deltaTime * transform.forward);
+            if (Physics.Raycast(transform.position, transform.forward, out RaycastHit hit, dashSpeed * Time.fixedDeltaTime, obstacleLayerMask))
+            {
+                break;
+            }
+            rb.MovePosition(rb.position + dashSpeed * Time.fixedDeltaTime * transform.forward);
             elapsedTime += Time.fixedDeltaTime;
             yield return new WaitForFixedUpdate();
         }
+        yield return new WaitForSeconds(duration - elapsedTime);
 
         Debug.Log("Trojan dash END");
     }


### PR DESCRIPTION
# 트로이목마 버그 #126 해결

## Related Issue(s)
#126 

### Changes Included
- [ ] #126 해결: Raycast로 Obstacle 감지
- [ ] 벽과 트로이목마 collider 위치 수정

### Notes for Reviewer
생각보다 버그 해결이 간단하지 않습니다. 속도가 너무 빨라서 collision이 fixedTime 내에 감지되지 않았던 것으로 보입니다.
rigidbody의 collision detection을 continuous 또는 continuous dynamic으로 변경하고 moveposition 대신 addforce를 쓰는 해결방법이 있는데 이렇게 하면 다른 virus의 rigidbody한테 막혀서 돌진을 못하는 문제가 새로 생겼습니다.
그래서 raycast로 벽을 감지하는 코드를 따로 썼습니다. 근데 이렇게 해도 완전히 매끄럽진 않습니다. 벽 안쪽에 살짝 들어갔다가 튕겨나옵니다.

https://github.com/user-attachments/assets/8e2bee05-4327-4d88-bb00-b472cb7fa7f0

이것보다 좋은 방법이 있을지는 잘 모르겠습니다.

---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

