### PR TITLE
fix : 비네팅 수정

### DIFF
--- a/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
@@ -143,6 +143,7 @@ public class PlayerController : MonoBehaviour
         StartCoroutine(BeInvincible());
         playerStat.CurrentHP -= damage;
         Debug.Log("Player HP: " + playerStat.CurrentHP);
+        playerHitEffect.PlayGetDamageEffect();
         if (playerStat.CurrentHP <= 0)
         {
             Die();
@@ -152,6 +153,7 @@ public class PlayerController : MonoBehaviour
     public void GetHeal(int heal)
     {
         playerStat.CurrentHP += heal;
+        playerHitEffect.PlayGetHealEffect();
     }
 
     public void GetSelectable()

--- a/Computer Virus Survivors/Assets/Scripts/Player/PlayerHitEffect.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Player/PlayerHitEffect.cs
@@ -6,16 +6,21 @@ using UnityEngine.Rendering.Universal;
 
 public class PlayerHitEffect : HitEffect
 {
+    private Color hitColor;
+    private Color healColor;
+
     private PlayerController player;
 
     public PlayerHitEffect(GameObject gameObject) : base(gameObject)
     {
         this.player = gameObject.GetComponent<PlayerController>();
 
-        player.statEventCaller.StatChangedHandler += OnPlayerStatChange;
-
         Volume volume = GameObject.FindObjectOfType<Volume>();
         volume.profile.TryGet(out vignette);
+
+        hitColor = new Color(43 / 255f, 8 / 255f, 8 / 255f);
+        healColor = new Color(24 / 255f, 82 / 255f, 12 / 255f);
+        SetColor(hitColor);
     }
 
     // 화면 비네팅
@@ -29,15 +34,27 @@ public class PlayerHitEffect : HitEffect
 
     public void OnPlayerStatChange(object o, StatChangedEventArgs args)
     {
-        if (args.StatName == nameof(PlayerStat.CurrentHP))
-        {
-            PlayVignette();
-            base.Play();
-        }
-        else if (args.StatName == nameof(PlayerStat.MaxHP))
+        if (args.StatName == nameof(PlayerStat.MaxHP))
         {
             SetVignette(GetIntensity(player.playerStat.CurrentHP / player.playerStat.MaxHP));
         }
+    }
+
+    public void PlayGetDamageEffect()
+    {
+        PlayVignette();
+        base.Play();
+    }
+
+    public void PlayGetHealEffect()
+    {
+        SetColor(healColor);
+        PlayVignette();
+    }
+
+    private void SetColor(Color color)
+    {
+        vignette.color.value = color;
     }
 
     private float GetIntensity(float hpRatio)
@@ -59,6 +76,7 @@ public class PlayerHitEffect : HitEffect
 
     private void SetVignette(float intensity)
     {
+        SetColor(hitColor);
         vignette.intensity.value = intensity;
     }
 


### PR DESCRIPTION
# PR 비네팅 수정
## Related Issue(s)
- #153 비네팅 효과 버그
## PR Description
체력 회복 시 빨간색 비네팅 효과가 나타나는 것을 수정했습니다.
체력 회복 시 초록색 비네팅 효과가 나타납니다.

### Changes Included
- [x] 체력 회복 비네팅 변경
### Screenshots (if UI changes were made)

### Notes for Reviewer
- #155 와 PlayerController에서 충돌이 날 수 있습니다.
---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---
## Additional Comments

