### PR TITLE
fix : 체력 회복 & 방어력 & 회피 구현

### DIFF
--- a/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
@@ -253,14 +253,15 @@ public class PlayerController : MonoBehaviour
         while (true)
         {
             yield return new WaitForSeconds(1);
-            int divided = playerStat.HealthRezenPer10 / 10;
-            remainHP += playerStat.HealthRezenPer10 % 10;
+            float hpRezenPerSecond = playerStat.HealthRezenPer10 / 10f;
+            int hpZenInt = (int) hpRezenPerSecond;
+            remainHP += hpRezenPerSecond - hpZenInt;
             if (remainHP > 1f)
             {
-                divided++;
+                hpZenInt++;
                 remainHP -= 1f;
             }
-            playerStat.CurrentHP += divided;
+            playerStat.CurrentHP += hpZenInt;
         }
     }
 }

--- a/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
@@ -184,6 +184,10 @@ public class PlayerController : MonoBehaviour
         {
             sphereCollider.radius = playerStat.ExpGainRange;
         }
+        else if (e.StatName == nameof(PlayerStat.HealthRezenPer10))
+        {
+            StartCoroutine(HPrezen());
+        }
     }
 
     public void DebuffMoveSpeed(float value)
@@ -212,5 +216,22 @@ public class PlayerController : MonoBehaviour
         playerStat.MoveSpeed *= -1;
         yield return new WaitForSeconds(duration);
         playerStat.MoveSpeed *= -1;
+    }
+
+    private IEnumerator HPrezen()
+    {
+        float remainHP = 0;
+        while (true)
+        {
+            yield return new WaitForSeconds(1);
+            int divided = playerStat.HealthRezenPer10 / 10;
+            remainHP += playerStat.HealthRezenPer10 % 10;
+            if (remainHP > 1f)
+            {
+                divided++;
+                remainHP -= 1f;
+            }
+            playerStat.CurrentHP += divided;
+        }
     }
 }

--- a/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
@@ -6,6 +6,7 @@ using Cst = GameConstants;
 
 public class PlayerController : MonoBehaviour
 {
+    public Action onPlayerEvade;
 
     public PlayerStatData playerStatData;
     public PlayerStatEventCaller statEventCaller;
@@ -141,6 +142,14 @@ public class PlayerController : MonoBehaviour
         }
 
         StartCoroutine(BeInvincible());
+        // 공격 회피
+        // 무적을 만들어 주지 않으면 몬스터랑 비비면서 다음 프레임에 다시 공격 받음
+        if (IsEvade())
+        {
+            // 회피 이펙트 추가용
+            onPlayerEvade?.Invoke();
+            return;
+        }
         playerStat.CurrentHP -= ReduceDamage(damage);
         Debug.Log("Player HP: " + playerStat.CurrentHP);
         if (playerStat.CurrentHP <= 0)
@@ -160,6 +169,13 @@ public class PlayerController : MonoBehaviour
             reducingDamageInt++;
         }
         return damage - reducingDamageInt;
+    }
+
+    private bool IsEvade()
+    {
+        float evadeDice = UnityEngine.Random.Range(0f, 1f);
+        Debug.Log("Evade dice: " + evadeDice);
+        return evadeDice < playerStat.EvadeProbability / 100f;
     }
 
     public void GetHeal(int heal)

--- a/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Player/PlayerController.cs
@@ -141,12 +141,25 @@ public class PlayerController : MonoBehaviour
         }
 
         StartCoroutine(BeInvincible());
-        playerStat.CurrentHP -= damage;
+        playerStat.CurrentHP -= ReduceDamage(damage);
         Debug.Log("Player HP: " + playerStat.CurrentHP);
         if (playerStat.CurrentHP <= 0)
         {
             Die();
         }
+    }
+
+    private int ReduceDamage(int damage)
+    {
+        float reduceRate = 1f - (7 / (7 + playerStat.DefencePoint + 0.1f * Mathf.Pow(playerStat.DefencePoint, 2)));
+        float reducingDamage = damage * reduceRate;
+        int reducingDamageInt = (int) reducingDamage;
+        float remain = reducingDamage - reducingDamageInt;
+        if (UnityEngine.Random.Range(0f, 1f) < remain)
+        {
+            reducingDamageInt++;
+        }
+        return damage - reducingDamageInt;
     }
 
     public void GetHeal(int heal)

--- a/Computer Virus Survivors/Assets/Scripts/Player/PlayerStat.cs
+++ b/Computer Virus Survivors/Assets/Scripts/Player/PlayerStat.cs
@@ -43,6 +43,7 @@ public class PlayerStat : IPlayerStatObserver
         }
         set
         {
+            int originalHP = currentHP;
             currentHP = value;
             if (currentHP < 0)
             {
@@ -52,7 +53,13 @@ public class PlayerStat : IPlayerStatObserver
             {
                 currentHP = maxHP;
             }
-            statEventCaller.Invoke(nameof(CurrentHP), currentHP);
+            if (originalHP != currentHP)
+            {
+                statEventCaller.Invoke(nameof(CurrentHP), currentHP);
+
+            }
+
+
         }
     }
 


### PR DESCRIPTION
# PR 체력 회복 & 데미지 감소 & 회피
## Related Issue(s)
- #153 체력 회복 미적용 & 방어력 미적용 & 회피 미적용
## PR Description
- 자동 체력 회복을 구현했습니다.
- 방어력에 따라 데미지가 감소되는 것을 구현했습니다. 감소 식은 스케줄 시트의 무기 스펙 탭을 참조 바랍니다.
- 회피 확률에 따른 회피를 구현했습니다. 회피에 성공하면 데미지를 받은 것과 같이 잠시 무적이 됩니다.
  회피 글자 표시를 위한 이벤트 핸들러를 달았습니다.
### Changes Included
- [ ] 체력 회복 구현
- [ ] 체력이 변할 때만 StatChange 이벤트를 부르도록 변경
- [ ] 방어력에 의한 데미지 감소 구현
- [ ] 회피 구현
### Screenshots (if UI changes were made)

### Notes for Reviewer
- #155 와 PlayerController에서 충돌이 날 수 있습니다.
---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---
## Additional Comments
